### PR TITLE
Patch for issues associated with pdfminer missing sub-modules ... cleaning for self-referencing packages

### DIFF
--- a/pdfparanoia/__init__.py
+++ b/pdfparanoia/__init__.py
@@ -1,29 +1,2 @@
 # -*- coding: utf-8 -*-
-"""
-pdfparanoia - pdf watermark remover library for academic papers
-~~~~~~~~~~~~~~~
-
-pdfparanoia is a pdf watermark remover library for academic papers. Basic
-usage:
-
-    >>> import pdfparanoia
-    >>> pdf = pdfparanoia.scrub(open("nmat.pdf", "r"))
-    >>> file_handler = open("output.pdf", "w")
-    >>> file_handler.write(pdf)
-    >>> file_handler.close()
-
-:copyright: (c) 2013 by Bryan Bishop.
-:license: BSD.
-"""
-
-__title__ = "pdfparanoia"
-__version__ = "0.0.13"
-__build__ = 0x000013
-__author__ = "Bryan Bishop <kanzure@gmail.com>"
-__license__ = "BSD"
-__copyright__ = "Copyright 2013 Bryan Bishop"
-
-from . import utils
-from .core import scrub
-from .parser import deflate
 

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,11 @@
 from setuptools import setup
 import os
 
-import pdfparanoia
-
 long_description = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
-
-packages = [
-    "pdfparanoia",
-    "pdfparanoia.plugins",
-]
 
 setup(
     name="pdfparanoia",
-    version=pdfparanoia.__version__,
+    version="0.0.13",
     url="https://github.com/kanzure/pdfparanoia",
     license="BSD",
     author="Bryan Bishop",
@@ -22,7 +15,6 @@ setup(
     maintainer_email="kanzure@gmail.com",
     description="pdf watermark remover library for academic papers",
     long_description=long_description,
-    packages=packages,
     install_requires=["pdfminer>=0"],
     scripts=["bin/pdfparanoia"],
     platforms="any",


### PR DESCRIPTION
setup.py should definitely not be importing any of your code
not recommended to put code in **init**.py 
-AND-
to have yourpackage/someotherthing.py
... so cleaned out **init**.py 

It would also be helpful to have a test PDF within the package to verify functionality.
